### PR TITLE
simplify and refactor makefile

### DIFF
--- a/doc/examples/Makefile
+++ b/doc/examples/Makefile
@@ -5,53 +5,26 @@ all: calendars bursts
 
 test: ./diff-cal.sh
 
-calendars: cal-plain cal-showtrims cal-showframe cal-varnishmask cal-translations cal-marks cal-year-planner cal-thumbnails
+calendars: cal-plain.pdf cal-showtrims.pdf cal-showframe.pdf cal-varnishmask.pdf cal-translations cal-marks.pdf cal-year-planner.pdf cal-thumbnails.pdf
 
 bursts: cal-plain-burst cal-showtrims-burst cal-showframe-burst cal-varnishmask-burst
 
-cal-plain:
-	$(LATEX) $(LATEX_OPTS) cal-plain.tex
+%.pdf: %.tex
+	$(LATEX) $(LATEX_OPTS) $<
 
 cal-plain-burst:
 	pdftk cal-plain.pdf burst output ./cal-burst/cal-plain-%02d.pdf
 
-cal-showtrims:
-	$(LATEX) $(LATEX_OPTS) cal-showtrims.tex
-
 cal-showtrims-burst:
 	pdftk cal-showtrims.pdf burst output ./cal-burst/cal-showtrims-%02d.pdf
-
-cal-showframe:
-	$(LATEX) $(LATEX_OPTS) cal-showframe.tex
 
 cal-showframe-burst:
 	pdftk cal-showframe.pdf burst output ./cal-burst/cal-showframe-%02d.pdf
 
-cal-varnishmask:
-	$(LATEX) $(LATEX_OPTS) cal-varnishmask.tex
-
 cal-varnishmask-burst:
 	pdftk cal-varnishmask.pdf burst output ./cal-burst/cal-varnishmask-%02d.pdf
 
-cal-translations-japanese:
-	$(LATEX) $(LATEX_OPTS) cal-translations-japanese.tex
-
-cal-translations-english:
-	$(LATEX) $(LATEX_OPTS) cal-translations-english.tex
-
-cal-translations-hungarian:
-	$(LATEX) $(LATEX_OPTS) cal-translations-hungarian.tex
-
-cal-translations: cal-translations-japanese cal-translations-english cal-translations-hungarian
-
-cal-marks:
-	$(LATEX) $(LATEX_OPTS) cal-marks.tex
-
-cal-year-planner:
-	$(LATEX) $(LATEX_OPTS) cal-year-planner.tex
-
-cal-thumbnails:
-	$(LATEX) $(LATEX_OPTS) cal-thumbnails.tex
+cal-translations: cal-translations-japanese.pdf cal-translations-english.pdf cal-translations-hungarian.pdf
 
 # For developing snippets in isolation.
 mwe:


### PR DESCRIPTION
This factors out the common latex build options.

I have tried to factor out the cal-burst stuff, but I am not sure I
understand how it works, so I left it alone.

In my local copy, I also have the following extra line:

```
calendes.pdf: data/*.csv fonts/* photos/*
```

Which makes sure the PDF file is updated when the fonts, photos or
data changes.

I also removed the font from my repository, since it can be
redownloaded on the fly:

```
fonts/josefin-sans.zip:
	wget -O $@ https://www.fontsquirrel.com/fonts/download/josefin-sans

fonts/JosefinSans-Regular.ttf: fonts/josefin-sans.zip
	unzip $< -d fonts/ JosefinSans-Regular.ttf
```

Finally, I also have a target to regenerate the moon phases.

Let me know if I should add those to the pull request.