### PR TITLE
fix computation of 6 row calendar

### DIFF
--- a/doc/wallcalendar-code.org
+++ b/doc/wallcalendar-code.org
@@ -374,10 +374,6 @@ argument.
     \ifnum\pgfcalendarifdateweekday=0\relax
       \pgfcalendarmatchestrue
     \fi
-    % Tuesday
-    \ifnum\pgfcalendarifdateweekday=1\relax
-      \pgfcalendarmatchestrue
-    \fi
   \else
     \ifnum\pgfcalendarifdateday=31\relax
       % Monday

--- a/wallcalendar.cls
+++ b/wallcalendar.cls
@@ -279,10 +279,6 @@
     \ifnum\pgfcalendarifdateweekday=0\relax
       \pgfcalendarmatchestrue
     \fi
-    % Tuesday
-    \ifnum\pgfcalendarifdateweekday=1\relax
-      \pgfcalendarmatchestrue
-    \fi
   \else
     \ifnum\pgfcalendarifdateday=31\relax
       % Monday


### PR DESCRIPTION
Currently a month with 30 days where the last day falls on a Tuesday is considered a six row calendar, but in fact it is only five rows, since the first falls on Monday.

Fix this computation.