### PR TITLE
remove bleed on "photo and notes" calendar page

### DIFF
--- a/doc/wallcalendar-code.org
+++ b/doc/wallcalendar-code.org
@@ -1682,16 +1682,15 @@ Default height to fit:
 - day headings
 - days in a grid, 6 rows
 - events
-- bottom bleed
 
 #+begin_src tex
-\setlength{\@t@calendar@height}{\@t@calendar@minimumHeight + \@t@bleed}
+\setlength{\@t@calendar@height}{\@t@calendar@minimumHeight}
 
 % See if there was a height given in the options
 \pgfkeys{/Calendar/#2/minimum height/.get=\@val}
 \ifx\@val\empty \relax
 \else
-  \setlength{\@t@calendar@height}{\@val + \@t@bleed}
+  \setlength{\@t@calendar@height}{\@val}
 \fi
 #+end_src
 
@@ -1707,7 +1706,7 @@ Calculate offsets:
 
 % NOTE: the -4pt and -2pt offset is somehow necessary for the sides to align
 % with the edges
-\setlength{\@t@rightOffset}{\@t@bleed +\@t@calendar@hmargin -4pt}
+\setlength{\@t@rightOffset}{\@t@calendar@hmargin -4pt}
 \setlength{\@t@minipageWidth}{\calPaperWidth -2\@t@calendar@hmargin -2pt}
 
 \setlength{\@t@calendar@dayXshift}{0.1428\@t@minipageWidth}% 1/7 = 0.1428
@@ -1786,7 +1785,7 @@ Calendar:
 \node (bg) [
   fill = calendarbg,
   opacity = 1,
-  minimum width = {\calPaperWidth + 2\@t@bleed},
+  minimum width = {\calPaperWidth},
   anchor=north west,
   /Calendar/#2/bg,
   % override the style, in case bleed was set above

--- a/wallcalendar.cls
+++ b/wallcalendar.cls
@@ -1221,13 +1221,13 @@ monthInlineNotes(\luastring{\theMonthName}, nil, \luastring{\@wall@eventsCsv}, \
 \end{tikzpicture}
 }
 
-\setlength{\@t@calendar@height}{\@t@calendar@minimumHeight + \@t@bleed}
+\setlength{\@t@calendar@height}{\@t@calendar@minimumHeight}
 
 % See if there was a height given in the options
 \pgfkeys{/Calendar/#2/minimum height/.get=\@val}
 \ifx\@val\empty \relax
 \else
-  \setlength{\@t@calendar@height}{\@val + \@t@bleed}
+  \setlength{\@t@calendar@height}{\@val}
 \fi
 
 \setlength{\@tmp@a}{\@t@calendar@verticalSpacing}
@@ -1239,7 +1239,7 @@ monthInlineNotes(\luastring{\theMonthName}, nil, \luastring{\@wall@eventsCsv}, \
 
 % NOTE: the -4pt and -2pt offset is somehow necessary for the sides to align
 % with the edges
-\setlength{\@t@rightOffset}{\@t@bleed +\@t@calendar@hmargin -4pt}
+\setlength{\@t@rightOffset}{\@t@calendar@hmargin -4pt}
 \setlength{\@t@minipageWidth}{\calPaperWidth -2\@t@calendar@hmargin -2pt}
 
 \setlength{\@t@calendar@dayXshift}{0.1428\@t@minipageWidth}% 1/7 = 0.1428
@@ -1292,7 +1292,7 @@ monthInlineNotes(\luastring{\theMonthName}, nil, \luastring{\@wall@eventsCsv}, \
 \node (bg) [
   fill = calendarbg,
   opacity = 1,
-  minimum width = {\calPaperWidth + 2\@t@bleed},
+  minimum width = {\calPaperWidth},
   anchor=north west,
   /Calendar/#2/bg,
   % override the style, in case bleed was set above


### PR DESCRIPTION
The bleed is set for the photo, but affects also the Calendar page. Remove references to the bleed there.

I think that the bleed should not affect the Calendar page in this setup. I use a negative bleed to shrink photos to less then the full page size, but it affects the Calendar page.

The patch removes the bleed from the calendar page.