### PR TITLE
Use the proper shortcut for Polish name of January

### DIFF
--- a/i18n/wallcalendar-polish.tex
+++ b/i18n/wallcalendar-polish.tex
@@ -13,7 +13,7 @@
 \def\xNovember{Listopad}
 \def\xDecember{Grudzień}
 
-\def\xJanShort{Jan}
+\def\xJanShort{Sty}
 \def\xFebShort{Lut}
 \def\xMarShort{Mar}
 \def\xAprShort{Kwi}


### PR DESCRIPTION
Since January is "Styczeń" in Polish, is should be shortened to "Sty", not to "Jan".